### PR TITLE
Adding unit test to route parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "This is a Blog which can be used to publish posts.",
   "main": "index.js",
   "scripts": {
+    "test": "./node_modules/elm-test/bin/elm-test",
     "start": "node server.js",
     "build": "webpack",
     "watch": "webpack --watch",
@@ -24,6 +25,7 @@
   },
   "homepage": "https://github.com/rodrigo-morais/in-development-blog#readme",
   "dependencies": {
+    "elm-test": "^0.17.3",
     "express": "^4.14.0"
   },
   "devDependencies": {

--- a/src/Routing/Parser.elm
+++ b/src/Routing/Parser.elm
@@ -1,4 +1,4 @@
-module Routing.Parser exposing (urlParser)
+module Routing.Parser exposing (urlParser, parser)
 
 
 import Navigation

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/elm-stuff/

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
+
+
+main : Program Value
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/RoutingParser.elm
+++ b/tests/RoutingParser.elm
@@ -1,0 +1,51 @@
+module RoutingParser exposing (all)
+
+
+import Test exposing (..)
+import Expect
+import Navigation
+
+import Routing.Models exposing (..)
+import Routing.Parser exposing (parser)
+
+
+all: Test
+all =
+  describe "Routing Parser"
+    [ test "Should parse '#/' to PostsRoute" <|
+        \() ->
+          Expect.equal (parse "#/") PostsRoute
+    , test "Should parse '#/admin' to AdminRoute" <|
+        \() ->
+          Expect.equal (parse "#/admin") AdminRoute
+    , test "Should parse '#/post/new' to NewPostRoute" <|
+        \() ->
+          Expect.equal (parse "#/post/new") NewPostRoute
+    , test "Should parse '#/post/10' to PostRoute" <|
+        \() ->
+          Expect.equal (parse "#/post/10") (PostRoute 10)
+    , test "Should parse '#/otherthing' to NotFoundRoute" <|
+        \() ->
+          Expect.equal (parse "#/otherthing") NotFoundRoute
+    ]
+
+
+parse : String -> Route
+parse hash =
+  parser (location hash)
+
+
+location : String -> Navigation.Location
+location hash =
+  { href = ""
+  , host = ""
+  , hostname = ""
+  , protocol = ""
+  , origin = ""
+  , port_ = ""
+  , pathname = ""
+  , search = ""
+  , hash = hash
+  , username = ""
+  , password = ""
+  }

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,20 @@
+module Tests exposing (..)
+
+import Test exposing (..)
+import Expect
+import String
+
+
+all : Test
+all =
+    describe "A Test Suite"
+        [ test "Addition" <|
+            \() ->
+                Expect.equal (3 + 7) 10
+        , test "String.left" <|
+            \() ->
+                Expect.equal "a" (String.left 1 "abcdefg")
+        , test "This test should fail" <|
+            \() ->
+                Expect.fail "failed as expected!"
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,20 +1,12 @@
 module Tests exposing (..)
 
 import Test exposing (..)
-import Expect
-import String
+
+import RoutingParser
 
 
 all : Test
 all =
-    describe "A Test Suite"
-        [ test "Addition" <|
-            \() ->
-                Expect.equal (3 + 7) 10
-        , test "String.left" <|
-            \() ->
-                Expect.equal "a" (String.left 1 "abcdefg")
-        , test "This test should fail" <|
-            \() ->
-                Expect.fail "failed as expected!"
+    describe "In development"
+        [ RoutingParser.all
         ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "summary": "Sample Elm Test",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD-3-Clause",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,7 +11,14 @@
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0"
+        "rtfeldman/node-test-runner": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
+        "elm-lang/virtual-dom": "1.0.2 <= v < 2.0.0",
+        "evancz/elm-http": "3.0.1 <= v < 4.0.0",
+        "evancz/elm-markdown": "3.0.0 <= v < 4.0.0",
+        "evancz/url-parser": "1.0.0 <= v < 2.0.0",
+        "truqu/elm-base64": "1.0.4 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
I was just playing with [elm-test](https://github.com/elm-community/elm-test) and decided to add tests to the url parser.

To run the tests, just execute `npm test`.

It works fine, but it bothers me that I couldn't manage to test `urlParser` directly, so I needed to expose `parser`. 
I tried to deconstruct the result of `urlParser` like they do in [elm-navigation](https://github.com/elm-lang/navigation/blob/1.0.0/src/Navigation.elm#L60) but I failed :(
